### PR TITLE
Add parseNumberedNotation

### DIFF
--- a/Source/midiplayer.h
+++ b/Source/midiplayer.h
@@ -76,7 +76,7 @@ namespace MIDIPlayer
 		uint8_t data;
 	};
 	struct NotationOctave { // -11 ~ 10
-		explicit NotationOctave(int8_t data = 0) : data(data) { assert(-11 <= data && data <= 10); }
+		explicit NotationOctave(int8_t data = 0) : data(data) {}
 		int8_t data;
 	};
 	struct Notation {

--- a/Source/parse.cpp
+++ b/Source/parse.cpp
@@ -57,16 +57,12 @@ MIDIPlayer::Pitch parsePitch(const char *word, const char *&end) {
 	return MIDIPlayer::Pitch(MIDIPlayer::Note(word), MIDIPlayer::Octave(num));
 }
 
-MIDIPlayer::Notation parseNumberedNotation(const char *word, const char *&end)
-{
-	size_t len = strlen(word);
+MIDIPlayer::Notation parseNumberedNotation(const char *word, const char *&end){
 	int base = 0;
 	int octave = 0;
 	int i = 0;
 	bool rise;
-	for (i = 0;i < len;++i) {
-		if (word[i] == '-' || word[i] == '+' || word[i] <= '7' && word[i] >= '1')
-		{
+		while (word[i] == '-' || word[i] == '+' || word[i] <= '7' && word[i] >= '1'){
 			if (word[i] == '-') {//if the first character is - 
 				if (word[0] == '-')//if this character is -
 					octave--;
@@ -87,22 +83,16 @@ MIDIPlayer::Notation parseNumberedNotation(const char *word, const char *&end)
 			}
 			else {
 				base = word[i] - '0';
-				if (i < len - 1 && word[i + 1] == '#')
+				if (word[i + 1] == '#')
 					rise = true;
 				else
 					rise = false;
 				break;
 			}
-
+			i++;
 		}
-		else {
-			printf("Illegal operation.The are wrong characters that out of the range.\n");
-			end = word;
-			return MIDIPlayer::Notation();
-		}
-	}
 	if (!base) {
-		printf("Illegal operation.There are no base number in this string.\n");
+		printf("Illegal operation.There are no base number in this string or there are wrong characters in it\n");
 		end = word;
 		return MIDIPlayer::Notation();
 	}

--- a/Source/parse.cpp
+++ b/Source/parse.cpp
@@ -14,7 +14,7 @@ MIDIPlayer::Pitch parsePitch(const char *word, const char *&end) {
 	//save the next character when first one is # or b
 	if (note[j] == '#' || note[j] == 'b') {
 		if (word[i] <= 'G' && word[i] >= 'A') {
-				note[++j] = word[i++];
+			note[++j] = word[i++];
 		}
 		else {
 			printf("Illegal operation.The character is not the charater between A and G.\n");
@@ -51,7 +51,7 @@ MIDIPlayer::Pitch parsePitch(const char *word, const char *&end) {
 			end = word;
 			return (MIDIPlayer::Pitch(0));
 		}
-			
+
 	}
 	end = &word[++i];
 	return MIDIPlayer::Pitch(MIDIPlayer::Note(word), MIDIPlayer::Octave(num));
@@ -59,5 +59,55 @@ MIDIPlayer::Pitch parsePitch(const char *word, const char *&end) {
 
 MIDIPlayer::Notation parseNumberedNotation(const char *word, const char *&end)
 {
-	return MIDIPlayer::Notation();
+	size_t len = strlen(word);
+	int base = 0;
+	int octave = 0;
+	int i = 0;
+	bool rise;
+	for (i = 0;i < len;++i) {
+		if (word[i] == '-' || word[i] == '+' || word[i] <= '7' && word[i] >= '1')
+		{
+			if (word[i] == '-') {//if the first character is - 
+				if (word[0] == '-')//if this character is -
+					octave--;
+				else {//if it is not ' either number of range
+					printf("Illegal operation.The are wrong characters when first character is '-'.\n");
+					end = word;
+					return MIDIPlayer::Notation();
+				}
+			}
+			else if (word[i] == '+') {
+				if (word[0] == '+')//if this character is +
+					octave++;
+				else {//if it is not ' either number of range
+					printf("Illegal operation.The are wrong characters when first character is '+'.\n");
+					end = word;
+					return MIDIPlayer::Notation();
+				}
+			}
+			else {
+				base = word[i] - '0';
+				if (i < len - 1 && word[i + 1] == '#')
+					rise = true;
+				else
+					rise = false;
+				break;
+			}
+
+		}
+		else {
+			printf("Illegal operation.The are wrong characters that out of the range.\n");
+			end = word;
+			return MIDIPlayer::Notation();
+		}
+	}
+	if (!base) {
+		printf("Illegal operation.There are no base number in this string.\n");
+		end = word;
+		return MIDIPlayer::Notation();
+	}
+	//printf("base:%d\t octave:%d\t rise:%d\n", base, octave, rise);
+	end = &word[octave + 1 + rise];
+	return MIDIPlayer::Notation(MIDIPlayer::NotationBase(base, rise), MIDIPlayer::NotationOctave(octave));
 }
+


### PR DESCRIPTION
在parse.cpp中添加了字符串->Notationde的parse函数，函数签名MIDIPlayer::Notation parseNumberedNotation(const char *word, const char *&end)
main.cpp中保留Test2函数用以审查。
删除了NotationOctave结构体中的assert语句，因为offset可以负责检查数据，不再需要此句。